### PR TITLE
Keep within array bounds when matching arrays

### DIFF
--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -309,6 +309,7 @@
         for (i = 0, l = array.length; i < l; ++i) {
             if (match(array[i], subset[0])) {
                 for (j = 0, k = subset.length; j < k; ++j) {
+                    if ((i + j) >= l) { return false; }
                     if (!match(array[i + j], subset[j])) { return false; }
                 }
                 return true;

--- a/test/samsam-test.js
+++ b/test/samsam-test.js
@@ -340,6 +340,7 @@ if (typeof module === "object" && typeof require === "function") {
         pass("matching array subset", [1, 2, 3, { id: 42 }], [{ id: 42 }]);
         fail("mis-matching array 'subset'", [1, 2, 3], [2, 3, 4]);
         fail("mis-ordered array 'subset'", [1, 2, 3], [1, 3]);
+        fail("mis-ordered, but similar arrays of objects", [{a: 'a'}, {a: 'aa'}], [{a: 'aa'}, {a: 'a'}]);
         pass("empty arrays", [], []);
         pass("objects with empty arrays", { xs: [] }, { xs: [] });
         fail("nested objects with different depth", { a: 1 }, { b: { c: 2 } });


### PR DESCRIPTION
When matching two similar arrays of objects which are mis-ordered, the "arrayContains" function goes beyond the bounds of the left hand side array and causes the match to blow up.

This PR adds a safety check in the array iteration.