### PR TITLE
Match dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: "0.10"
-  - nodejs_version: "0.12"
   - nodejs_version: "4"
   - nodejs_version: "5"
 

--- a/lib/samsam.js
+++ b/lib/samsam.js
@@ -360,6 +360,10 @@
             return arrayContains(object, matcher);
         }
 
+        if (isDate(matcher)) {
+            return isDate(object) && object.getTime() === matcher.getTime();
+        }
+
         if (matcher && typeof matcher === "object") {
             if (matcher === object) {
                 return true;

--- a/test/samsam-test.js
+++ b/test/samsam-test.js
@@ -374,6 +374,11 @@ if (typeof module === "object" && typeof require === "function") {
         pass("undefined matches undefined", undefined, undefined);
         fail("undefined does not match null", undefined, null);
 
+        var date = new Date();
+        var sameDate = new Date(date.getTime());
+        var anotherDate = new Date(date.getTime() - 10);
+        pass("date objects with same date", date, sameDate);
+        fail("date objects with different dates", date, anotherDate);
     });
 
     tests("isArguments", function (pass, fail) {


### PR DESCRIPTION
The match-function does not handle date objects and yields false positives when matching objects with different dates.

Example:
```javascript
samsam.match({d = new Date(2017, 8, 28)}, {d: new Date(2017, 8, 29});
// => true
```

This PR copies the date handling from `deepEqual`.